### PR TITLE
Build RIOT without any extra patches

### DIFF
--- a/build_nimble_riot.sh
+++ b/build_nimble_riot.sh
@@ -30,6 +30,7 @@ pushd $RIOT_PATH
 pushd pkg/nimble/
 sed -i'.bak' 's|PKG_URL.*|PKG_URL = '"$NIMBLE_URL"'|' Makefile
 sed -i'.bak' 's|PKG_VERSION.*|PKG_VERSION = '"$NIMBLE_VER"'|' Makefile
+rm patches/ -rf
 
 # `ble_hs_stop.c` isn't in an official nimble release yet.  Add it to the
 # makefile.


### PR DESCRIPTION
The goal is to always have all changes in NimBLE in upstream repo so if
there are any extra patches they most likely exist because something is
not yet merged or pkg is not updated to use new commit.