### PR TITLE
Fix install gcc-arm-embedded after removal

### DIFF
--- a/osx_travis_install.sh
+++ b/osx_travis_install.sh
@@ -36,6 +36,10 @@ else
 
     PKGS=()
 
+    pushd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask
+    git checkout b3a2e0c930~
+    popd
+
     # FIXME: casks don't work with `fetch --retry`
     brew cask install gcc-arm-embedded
 fi


### PR DESCRIPTION
gcc-arm-embedded was removed from repo because it's open source and should be a standard formula. While this does not happen just checkout the latest repo that still had it.