### PR TITLE
brew: clone full tap repo

### DIFF
--- a/osx_travis_install.sh
+++ b/osx_travis_install.sh
@@ -32,13 +32,15 @@ if [ "${TEST}" == "TEST_ALL" ]; then
     PKGS=(gcc5)
 else
     brew untap caskroom/cask
-    brew tap homebrew/cask
 
-    PKGS=()
+    # Tap full clone to allow checkout of specific sha below
+    brew tap --full homebrew/cask
 
     pushd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask
     git checkout b3a2e0c930~
     popd
+
+    PKGS=()
 
     # FIXME: casks don't work with `fetch --retry`
     brew cask install gcc-arm-embedded


### PR DESCRIPTION
Allow brew tap to clone the full casks repo, because gcc-arm-embedded was removed and we have to checkout the latest sha that had it available.