### PR TITLE
test_newt_dump.sh: Fix paths

### DIFF
--- a/test_newt_dump.sh
+++ b/test_newt_dump.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cd ci/newt_dump/proj || exit 1
+cd $HOME/ci/newt_dump/proj || exit 1
 
 # Ensure newt generates the expected intermediate representation of each
 # target.


### PR DESCRIPTION
Prepend directories with `ci`.