### PR TITLE
Remove debug `$import` from my_blinky_sim target

### DIFF
--- a/newt_dump/proj/targets/my_blinky_sim/syscfg.yml
+++ b/newt_dump/proj/targets/my_blinky_sim/syscfg.yml
@@ -1,5 +1,2 @@
-$import:
-    - 'misc/importa.yml'
-
 syscfg.vals:
     HAL_FLASH_VERIFY_ERASES: 1


### PR DESCRIPTION
This import was added by accident while testing a different newt feature!