### PR TITLE
Always use /bin/bash -x for script execution

### DIFF
--- a/build_nimble_riot.sh
+++ b/build_nimble_riot.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -x
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/build_ports.sh
+++ b/build_ports.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -x
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/linux_toolchain_install.sh
+++ b/linux_toolchain_install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -x
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/newt_install.sh
+++ b/newt_install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/bash -x
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/osx_travis_install.sh
+++ b/osx_travis_install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -x
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/prepare_test.sh
+++ b/prepare_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/test_build_blinky.sh
+++ b/test_build_blinky.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/test_build_targets.sh
+++ b/test_build_targets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/test_newt.sh
+++ b/test_newt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -x
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Since scripts are using bash extensions make sure to use bash for
executing. Also make all scripts use verbose logging for easier
issues debugging.