### PR TITLE
Update newt_dump answer for recent newt fix

### DIFF
--- a/newt_dump/answers/my_blinky_sim.json
+++ b/newt_dump/answers/my_blinky_sim.json
@@ -1563,10 +1563,6 @@
         "console": "@apache-mynewt-core/sys/console/stub"
     },
     "unsatisfied_apis": {
-        "console": [
-            "@apache-mynewt-core/hw/mcu/native",
-            "@apache-mynewt-core/kernel/os"
-        ],
         "log": [
             "@apache-mynewt-core/sys/log/modlog"
         ]


### PR DESCRIPTION
Some extraneous APIs were being reported as unsatisfied.  This has been fixed in newt (468c75ad88a741d4ef2d2b03d38d36d36b8c4b9d), so update the dump answer with the correct output.