### PR TITLE
Add NimBLE targets for exercising SM configurations

### DIFF
--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_legacy/pkg.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_legacy/pkg.yml
@@ -1,0 +1,5 @@
+pkg.name: "targets/nrf52840pdk_btshell_sm_legacy"
+pkg.type: "target"
+pkg.description: 
+pkg.author: 
+pkg.homepage: 

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_legacy/syscfg.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_legacy/syscfg.yml
@@ -1,0 +1,3 @@
+syscfg.vals:
+    BLE_SM_LEGACY: 1
+    BLE_SM_SC: 0

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_legacy/target.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_legacy/target.yml
@@ -1,0 +1,3 @@
+target.app: "@apache-mynewt-nimble/apps/btshell"
+target.bsp: "@apache-mynewt-core/hw/bsp/nrf52840pdk"
+target.build_profile: "debug"

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_none/pkg.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_none/pkg.yml
@@ -1,0 +1,5 @@
+pkg.name: "targets/nrf52840pdk_btshell_sm_none"
+pkg.type: "target"
+pkg.description: 
+pkg.author: 
+pkg.homepage: 

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_none/syscfg.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_none/syscfg.yml
@@ -1,0 +1,3 @@
+syscfg.vals:
+    BLE_SM_LEGACY: 0
+    BLE_SM_SC: 0

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_none/target.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_none/target.yml
@@ -1,0 +1,3 @@
+target.app: "@apache-mynewt-nimble/apps/btshell"
+target.bsp: "@apache-mynewt-core/hw/bsp/nrf52840pdk"
+target.build_profile: "debug"

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc/pkg.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc/pkg.yml
@@ -1,0 +1,5 @@
+pkg.name: "targets/nrf52840pdk_btshell_sm_sc"
+pkg.type: "target"
+pkg.description: 
+pkg.author: 
+pkg.homepage: 

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc/syscfg.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc/syscfg.yml
@@ -1,0 +1,3 @@
+syscfg.vals:
+    BLE_SM_LEGACY: 0
+    BLE_SM_SC: 1

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc/target.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc/target.yml
@@ -1,0 +1,3 @@
+target.app: "@apache-mynewt-nimble/apps/btshell"
+target.bsp: "@apache-mynewt-core/hw/bsp/nrf52840pdk"
+target.build_profile: "debug"

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc_legacy/pkg.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc_legacy/pkg.yml
@@ -1,0 +1,5 @@
+pkg.name: "targets/nrf52840pdk_btshell_sm_sc_legacy"
+pkg.type: "target"
+pkg.description: 
+pkg.author: 
+pkg.homepage: 

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc_legacy/syscfg.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc_legacy/syscfg.yml
@@ -1,0 +1,3 @@
+syscfg.vals:
+    BLE_SM_LEGACY: 1
+    BLE_SM_SC: 1

--- a/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc_legacy/target.yml
+++ b/mynewt-nimble-targets/nrf52840pdk_btshell_sm_sc_legacy/target.yml
@@ -1,0 +1,3 @@
+target.app: "@apache-mynewt-nimble/apps/btshell"
+target.bsp: "@apache-mynewt-core/hw/bsp/nrf52840pdk"
+target.build_profile: "debug"


### PR DESCRIPTION
Make sure we always build all configuration regardless of btshell
defaults.