### PR TITLE
newt_dump: On failure, exit with nonzero status

### DIFF
--- a/newt_dump/answers/btshell-nrf52840pdk.json
+++ b/newt_dump/answers/btshell-nrf52840pdk.json
@@ -2829,7 +2829,7 @@
                     },
                     {
                         "value": "0",
-                        "package": "targets/btshell-nrf52840pdk"
+                        "package": "@apache-mynewt-nimble/apps/btshell"
                     },
                     {
                         "value": "0",
@@ -2898,8 +2898,8 @@
                         "package": "@apache-mynewt-nimble/nimble/host"
                     },
                     {
-                        "value": "1",
-                        "package": "targets/btshell-nrf52840pdk"
+                        "value": "0",
+                        "package": "@apache-mynewt-nimble/apps/btshell"
                     },
                     {
                         "value": "1",
@@ -3690,8 +3690,8 @@
                         "package": "@apache-mynewt-core/sys/log/full"
                     },
                     {
-                        "value": "0",
-                        "package": "targets/btshell-nrf52840pdk"
+                        "value": "1",
+                        "package": "@apache-mynewt-nimble/apps/btshell"
                     },
                     {
                         "value": "0",

--- a/newt_dump/answers/btshell-nrf52dk.json
+++ b/newt_dump/answers/btshell-nrf52dk.json
@@ -2829,7 +2829,7 @@
                     },
                     {
                         "value": "0",
-                        "package": "targets/btshell-nrf52dk"
+                        "package": "@apache-mynewt-nimble/apps/btshell"
                     },
                     {
                         "value": "0",
@@ -2898,8 +2898,8 @@
                         "package": "@apache-mynewt-nimble/nimble/host"
                     },
                     {
-                        "value": "1",
-                        "package": "targets/btshell-nrf52dk"
+                        "value": "0",
+                        "package": "@apache-mynewt-nimble/apps/btshell"
                     },
                     {
                         "value": "1",
@@ -3690,8 +3690,8 @@
                         "package": "@apache-mynewt-core/sys/log/full"
                     },
                     {
-                        "value": "0",
-                        "package": "targets/btshell-nrf52dk"
+                        "value": "1",
+                        "package": "@apache-mynewt-nimble/apps/btshell"
                     },
                     {
                         "value": "0",

--- a/test_newt_dump.sh
+++ b/test_newt_dump.sh
@@ -21,6 +21,7 @@ cd $HOME/ci/newt_dump/proj || exit 1
 
 # Ensure newt generates the expected intermediate representation of each
 # target.
+status=0
 for i in ../answers/*
 do
     target="$(basename $i)"
@@ -28,4 +29,13 @@ do
 
     printf "Checking target \"$target\"\n"
     diff "$i" <(newt target dump "$target")
+    rc="$?"
+
+    # Remember failure.
+    if [ "$rc" -ne 0 ]
+    then
+        status="$rc"
+    fi
 done
+
+exit "$status"


### PR DESCRIPTION
The `test_newt_dump.sh` script was printing results, but not forwarding the exit status up to travis.

In addition, some of the newt dump answers were incorrect (due to this bug, since fixed: https://github.com/apache/mynewt-newt/pull/294).  The mistake was not caught because the "newt dump" test was not failing on error.