### PR TITLE
Add script to generate `newt dump` answers

### DIFF
--- a/newt_dump/generate-answers.sh
+++ b/newt_dump/generate-answers.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+print_usage() {
+    echo "Generates known-answer json files for the newt dump tests." >&2
+    echo "Must be run from the 'newt_dump' directory." >&2
+    echo >&2
+    echo "usage: generate-answers.sh" >&2
+}
+
+usage_err() {
+    if [ "$1" != "" ]
+    then
+        printf '* error: %s\n\n' "$1" >&2
+        print_usage
+        exit 1
+    fi
+}
+
+TARGETS_DIR='proj/targets'
+
+if [ ! -d "$TARGETS_DIR" ]
+then
+    usage_err "cannot find $TARGETS_DIR directory"
+fi
+
+if [ "$1" = '-h' ]
+then
+    print_usage
+    exit 0
+fi
+
+# Run this in a subshell so that the user's PWD is preserved.
+(
+    cd "$TARGETS_DIR" &&
+    for t in *
+    do
+        if ! [ "$t" = 'unittest' ]
+        then
+            filename="answers/$t.json"
+            echo "Generating $filename"
+            newt target dump "$t" > "../../$filename"
+        fi
+    done
+)


### PR DESCRIPTION
This script overwrites the contents of `newt_dump/answers/...`

Use this to bring the answers up to date when new dump output is added to newt (or when a newt bug is fixed).