### PR TITLE
Include custom commands in "dump" answers

### DIFF
--- a/newt_dump/answers/bleprph-nrf52840pdk.json
+++ b/newt_dump/answers/bleprph-nrf52840pdk.json
@@ -7588,6 +7588,15 @@
             }
         ]
     },
+    "pre_build_cmds": {
+        "cmds": []
+    },
+    "pre_link_cmds": {
+        "cmds": []
+    },
+    "post_link_cmds": {
+        "cmds": []
+    },
     "logcfg": {
         "logs": {}
     },

--- a/newt_dump/answers/boot-nrf52dk.json
+++ b/newt_dump/answers/boot-nrf52dk.json
@@ -3326,6 +3326,15 @@
     "sysdown": {
         "funcs": []
     },
+    "pre_build_cmds": {
+        "cmds": []
+    },
+    "pre_link_cmds": {
+        "cmds": []
+    },
+    "post_link_cmds": {
+        "cmds": []
+    },
     "logcfg": {
         "logs": {}
     },

--- a/newt_dump/answers/btshell-nrf52840pdk.json
+++ b/newt_dump/answers/btshell-nrf52840pdk.json
@@ -5919,6 +5919,15 @@
             }
         ]
     },
+    "pre_build_cmds": {
+        "cmds": []
+    },
+    "pre_link_cmds": {
+        "cmds": []
+    },
+    "post_link_cmds": {
+        "cmds": []
+    },
     "logcfg": {
         "logs": {}
     },

--- a/newt_dump/answers/btshell-nrf52dk.json
+++ b/newt_dump/answers/btshell-nrf52dk.json
@@ -5919,6 +5919,15 @@
             }
         ]
     },
+    "pre_build_cmds": {
+        "cmds": []
+    },
+    "pre_link_cmds": {
+        "cmds": []
+    },
+    "post_link_cmds": {
+        "cmds": []
+    },
     "logcfg": {
         "logs": {}
     },

--- a/newt_dump/answers/my_blinky_sim.json
+++ b/newt_dump/answers/my_blinky_sim.json
@@ -1556,6 +1556,15 @@
     "sysdown": {
         "funcs": []
     },
+    "pre_build_cmds": {
+        "cmds": []
+    },
+    "pre_link_cmds": {
+        "cmds": []
+    },
+    "post_link_cmds": {
+        "cmds": []
+    },
     "logcfg": {
         "logs": {}
     },


### PR DESCRIPTION
Newt was updated to include custom commands in its dump output (https://github.com/apache/mynewt-newt/pull/352).  That change causes the "dump" test to fail because the test answers were generated by an older version of newt.

This PR updates the "dump test" answers to contain empty custom command lists.

This change was made by running the `newt_dump/generate_answers.sh` script.