### PR TITLE
test_newt_cmds: Test util/cbmem, not kernel/os

### DIFF
--- a/test_newt_cmds.sh
+++ b/test_newt_cmds.sh
@@ -55,7 +55,7 @@ declare -a commands=(
 )
 
 if [ "${TRAVIS_OS_NAME}" != "windows" ]; then
-    commands+=("newt test @apache-mynewt-core/kernel/os")
+    commands+=("newt test @apache-mynewt-core/util/cbmem")
     commands+=("newt build my_blinky_sim")
     commands+=("newt clean my_blinky_sim")
 fi


### PR DESCRIPTION
The kernel/os tests in the latest release are failing.  The kernel/os problem has since been fixed, but the newt tests will continue to fail until a new mynewt-core release is made (containing the fixes).

Work around this failure by testing a different package (util/cbmem).