### PR TITLE
Fix/refactor issues with running style checks

### DIFF
--- a/utils/backend.py
+++ b/utils/backend.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import os
+import requests
+import zlib
+
+GH_COMMENTER_URL = "https://github-commenter-l845aj3j3m9f.runkit.sh"
+GH_STATUS_REPORTER_URL = \
+    "https://github-status-reporter-eb26h8raupyw.runkit.sh"
+
+
+def new_comment(owner, repo, pr, comment_body):
+    headers = {
+        'Content-Encoding': 'deflate',
+        'Content-Type': 'application/json',
+    }
+    payload = zlib.compress(json.dumps({
+        'owner': owner,
+        'repo': repo,
+        'number': pr,
+        'body': comment_body,
+    }).encode('utf-8'))
+    r = requests.post(GH_COMMENTER_URL, data=payload, headers=headers)
+    return r.status_code == 200
+
+
+def send_status(owner, repo, sha, state):
+    headers = {
+        'Content-Encoding': 'deflate',
+        'Content-Type': 'application/json',
+    }
+    payload = zlib.compress(json.dumps({
+        'owner': owner,
+        'repo': repo,
+        'target_url': os.environ['TRAVIS_BUILD_WEB_URL'],
+        'sha': sha,
+        'state': state,
+    }).encode('utf-8'))
+    r = requests.post(GH_STATUS_REPORTER_URL, data=payload, headers=headers)
+    return r.status_code == 200

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import subprocess
+
+
+def run_git_command(cmd, log):
+    if log:
+        print("Executing: " + cmd)
+    output = subprocess.check_output(cmd.split()).decode()
+    if log:
+        print("output: " + output)
+    return output
+
+
+def get_added_files(commit_range, log=False):
+    '''
+    Get a list of new files added in the current PR
+    '''
+    cmd = "git diff --no-commit-id --name-only -r --diff-filter=A {}".format(
+        commit_range)
+    output = run_git_command(cmd, log)
+    return output.splitlines()
+
+
+def get_changed_files(commit_range, log=False):
+    '''
+    Get a list of existing files changed in current PR
+    '''
+    cmd = "git diff --no-commit-id --name-only -r --diff-filter=M {}".format(
+        commit_range)
+    output = run_git_command(cmd, log)
+    return output.splitlines()
+
+
+def get_commit_list(commit_range, log=False):
+    '''
+    Get a list of commits in this PR, from older to newer
+    '''
+    first, last = commit_range.split('...')
+    cmd = "git log --pretty=format:%H {}..{}".format(first+'~', last)
+    output = run_git_command(cmd, log)
+    # revert to get from older to newer
+    return output.splitlines()[::-1]


### PR DESCRIPTION
This breaks style checking into two options:

* For new files: style check all content
* For changes files: check what was changed from original file, do style check and remove style suggestions that already existed in the original file

Some of the shared functions were moved to a new package called `util`, to be used by both style and license checking. `util/cli.py` has a few external commands like `git` based utility functions, `util/backend.py` does communication with the service that communicates with GH. The communication was upgrade to compress data in the POST (much faster!). It should still work with PRs based on previous trees that are not using compression.