### PR TITLE
Fix intersection check in style

### DIFF
--- a/check_style.py
+++ b/check_style.py
@@ -214,7 +214,7 @@ def get_changed_style_diff(f, commit_range):
                 ln, n = int(m.group(1)), int(m.group(2))
                 for r in ranges:
                     # does the current chunk intesect with some range?
-                    if ln + n > r[0] and n < (r[0] + r[1]):
+                    if ln + n > r[0] and ln < (r[0] + r[1]):
                         valid = True
                         break
             if valid:


### PR DESCRIPTION
Fix check for intersection that was comparing the number of lines changed instead of line number to verify against the last line of the original modification diff chunk.