### PR TITLE
Fix ignored dirs parsing

### DIFF
--- a/check_license.py
+++ b/check_license.py
@@ -230,8 +230,12 @@ comment = """
 
 if DEBUG:
     print("Comment body: ", comment)
-if not backend.new_comment(owner, repo, TRAVIS_PULL_REQUEST, comment):
-    exit(1)
+try:
+    if not backend.new_comment(owner, repo, TRAVIS_PULL_REQUEST, comment):
+        exit(1)
+except backend.HttpError as e:
+    comment = LICENSE_BOT_ID + "\n## License check fail: " + str(e)
+    backend.new_comment(owner, repo, TRAVIS_PULL_REQUEST, comment)
 
 # FIXME: check category-x?
 sha, state = None, None

--- a/check_style.py
+++ b/check_style.py
@@ -271,8 +271,12 @@ def main():
     if DEBUG:
         print("Comment body: ", comment)
     owner, repo = TRAVIS_REPO_SLUG.split("/")
-    if not backend.new_comment(owner, repo, TRAVIS_PULL_REQUEST, comment):
-        exit(1)
+    try:
+        if not backend.new_comment(owner, repo, TRAVIS_PULL_REQUEST, comment):
+            exit(1)
+    except backend.HttpError as e:
+        comment = STYLE_BOT_ID + "\n## Style check fail: " + str(e)
+        backend.new_comment(owner, repo, TRAVIS_PULL_REQUEST, comment)
 
 
 if __name__ == '__main__':

--- a/check_style.py
+++ b/check_style.py
@@ -62,7 +62,7 @@ def load_ignored_dirs():
         lines = f.readlines()
         for line in lines:
             line = line.strip()
-            if line != "" and regex.match(line) is not None:
+            if line != "" and regex.match(line) is None:
                 IGNORED_DIRS.append(line)
 
 


### PR DESCRIPTION
Fix issue that happened in https://github.com/apache/mynewt-core/pull/2207 where ignored dirs was not being correctly used.

* Parsing ignored dirs was doing a reverse regex check where commented lines instead of uncommented were being added to the list of ignored dirs instead of skipped.
* Also abort early when payload submitted to backend is too large