### PR TITLE
Try 3 times before giving up on installing newt tool

### DIFF
--- a/newt_install.sh
+++ b/newt_install.sh
@@ -17,6 +17,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+retry_3_times() {
+    for i in 1 2 3; do
+        $*
+        [[ $? -eq 0 ]] && break
+        [[ $i -eq 3 ]] && exit 1
+        sleep 30
+    done
+}
+
 export GOPATH=$HOME/gopath
 export GO111MODULE=on
 
@@ -24,17 +33,10 @@ mkdir -p $HOME/bin $GOPATH || true
 
 go version
 
-for i in 1 2 3
-do
-   go get mynewt.apache.org/newt/newt
-   [[ $? -eq 0 ]] && break
-   [[ $i -eq 3 ]] && exit 1
-   sleep 30
-done
+retry_3_times go get -v mynewt.apache.org/newt/newt
 
 rm -rf $GOPATH/bin $GOPATH/pkg
 
-go install mynewt.apache.org/newt/newt
-[[ $? -ne 0 ]] && exit 1
+retry_3_times go install -v mynewt.apache.org/newt/newt
 
 cp $GOPATH/bin/newt $HOME/bin


### PR DESCRIPTION
It looks like occasionally go install can fail due to networking issues
and CI build fails due to newt tool not found. Try 3 times before
giving up.

2026 go install mynewt.apache.org/newt/newt
2027 go: mynewt.apache.org/newt@v0.0.0-20200221234103-9e6fc3de4272:
       unrecognized import path "mynewt.apache.org/newt" (https fetch:
       Get https://mynewt.apache.org/newt?go-get=1: dial tcp
       95.216.24.32:443: i/o timeout)
2028 go: error loading module requirements