### PR TITLE
newt_upgrade: Update some tests due to dummy mods

### DIFF
--- a/newt_upgrade/success/basic01/expected.txt
+++ b/newt_upgrade/success/basic01/expected.txt
@@ -1,5 +1,5 @@
     * mynewt-dummy-repo-01: 11badf27c834a587f9a4d14c30f861bc10af75c4, 0.0.0
-    * mynewt-dummy-repo-02: c25ed5e94df1a940d697d78798d7465096e088e8, 0.0.0
-    * mynewt-dummy-repo-03: 266a760e278beb0992aa0762fe0ef2eba2271feb, 0.0.0
+    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 0.0.0
+    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 0.0.0
     * mynewt-dummy-repo-04: 503782e265da53629ed26af485d01a3b7ac80cbd, 0.0.0
     * mynewt-dummy-repo-05: 59a441a8d183bab2f0f5bb5c3306462c9ddf86cd, 0.0.0

--- a/newt_upgrade/success/branches01/expected.txt
+++ b/newt_upgrade/success/branches01/expected.txt
@@ -1,5 +1,5 @@
     * mynewt-dummy-repo-01: 0d52ff5eed266459edda0384d41745acb4297c89
-    * mynewt-dummy-repo-02: c25ed5e94df1a940d697d78798d7465096e088e8, 0.0.0
-    * mynewt-dummy-repo-03: 266a760e278beb0992aa0762fe0ef2eba2271feb, 0.0.0
+    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 0.0.0
+    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 0.0.0
     * mynewt-dummy-repo-04: 503782e265da53629ed26af485d01a3b7ac80cbd, 0.0.0
     * mynewt-dummy-repo-05: ea8ffb94ad4ddb39c5179924316f0ebef1e2c90f


### PR DESCRIPTION
It's unfortunate, but some of these tests need to change any time
anything is pushed to one of the mynewt_dummy repos.  If a test leaves a
repo pointed to master (0.0.0), then the project state changes whenever
anything is pushed to the repo.

These tests should be updated to never use master / 0.0.0.  In the
meantime, this commit just updates the tests to use the latest master
branches.