### PR TITLE
newt_upgrade test for rc-tag inference

### DIFF
--- a/newt_upgrade/success/inferrc/expected.txt
+++ b/newt_upgrade/success/inferrc/expected.txt
@@ -1,0 +1,2 @@
+    * mynewt-dummy-repo-02: 603212f5105432b0db36336931d8dcd85f9038ff, 0.0.0
+    * mynewt-dummy-repo-03: 5df87b6ab70d2d6464f68e733b1d67c1652e0954, 0.0.0

--- a/newt_upgrade/success/inferrc/project.yml
+++ b/newt_upgrade/success/inferrc/project.yml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+repository.mynewt-dummy-repo-02:
+   type: git
+   vers: 2.0.1
+   url: 'git@github.com:JuulLabs-OSS/mynewt-dummy-repo-02.git'


### PR DESCRIPTION
NOTE: These modified tests will fail until https://github.com/apache/mynewt-newt/pull/387 is merged.