### PR TITLE
Add scanner and advertiser

### DIFF
--- a/mynewt-core-targets/nordic_pca10056_advertiser/pkg.yml
+++ b/mynewt-core-targets/nordic_pca10056_advertiser/pkg.yml
@@ -1,0 +1,5 @@
+pkg.name: "targets/nordic_pca10056_advertiser"
+pkg.type: "target"
+pkg.description:
+pkg.author:
+pkg.homepage:

--- a/mynewt-core-targets/nordic_pca10056_advertiser/target.yml
+++ b/mynewt-core-targets/nordic_pca10056_advertiser/target.yml
@@ -1,0 +1,2 @@
+target.app: "@apache-mynewt-nimble/apps/advertiser"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"

--- a/mynewt-core-targets/nordic_pca10056_scanner/pkg.yml
+++ b/mynewt-core-targets/nordic_pca10056_scanner/pkg.yml
@@ -1,0 +1,6 @@
+pkg.name: targets/scanner
+pkg.type: target
+pkg.description: 
+pkg.author: 
+pkg.homepage: 
+

--- a/mynewt-core-targets/nordic_pca10056_scanner/target.yml
+++ b/mynewt-core-targets/nordic_pca10056_scanner/target.yml
@@ -1,0 +1,2 @@
+target.app: "@apache-mynewt-nimble/apps/scanner"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"

--- a/mynewt-nimble-targets/nordic_pca10056_advertiser/pkg.yml
+++ b/mynewt-nimble-targets/nordic_pca10056_advertiser/pkg.yml
@@ -1,0 +1,5 @@
+pkg.name: "targets/nordic_pca10056_advertiser"
+pkg.type: "target"
+pkg.description:
+pkg.author:
+pkg.homepage:

--- a/mynewt-nimble-targets/nordic_pca10056_advertiser/target.yml
+++ b/mynewt-nimble-targets/nordic_pca10056_advertiser/target.yml
@@ -1,0 +1,2 @@
+target.app: "@apache-mynewt-nimble/apps/advertiser"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"

--- a/mynewt-nimble-targets/nordic_pca10056_scanner/pkg.yml
+++ b/mynewt-nimble-targets/nordic_pca10056_scanner/pkg.yml
@@ -1,0 +1,6 @@
+pkg.name: targets/scanner
+pkg.type: target
+pkg.description: 
+pkg.author: 
+pkg.homepage: 
+

--- a/mynewt-nimble-targets/nordic_pca10056_scanner/target.yml
+++ b/mynewt-nimble-targets/nordic_pca10056_scanner/target.yml
@@ -1,0 +1,2 @@
+target.app: "@apache-mynewt-nimble/apps/scanner"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"

--- a/newt_dump/proj/repos/apache-mynewt-nimble/apps/advertiser/pkg.yml
+++ b/newt_dump/proj/repos/apache-mynewt-nimble/apps/advertiser/pkg.yml
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: "apps/advertiser"
+pkg.type: app
+pkg.description: "Basic advertiser application"
+pkg.author: "Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>"
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-nimble/nimble/host/util"
+    - "@apache-mynewt-nimble/nimble/host/services/gap"
+    - "@apache-mynewt-nimble/nimble/transport"

--- a/newt_dump/proj/repos/apache-mynewt-nimble/apps/advertiser/syscfg.yml
+++ b/newt_dump/proj/repos/apache-mynewt-nimble/apps/advertiser/syscfg.yml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+syscfg.vals:
+    BLE_ROLE_BROADCASTER: 1
+    BLE_ROLE_CENTRAL: 0
+    BLE_ROLE_OBSERVER: 0
+    BLE_ROLE_PERIPHERAL: 0

--- a/newt_dump/proj/repos/apache-mynewt-nimble/apps/scanner/pkg.yml
+++ b/newt_dump/proj/repos/apache-mynewt-nimble/apps/scanner/pkg.yml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: "apps/scanner"
+pkg.type: app
+pkg.description: "Basic scanning application"
+pkg.author: "Krzysztof Kopyściński <krzysztof.kopyscinski@codecoup.pl>"
+
+
+pkg.deps:
+    - "@apache-mynewt-core/kernel/os"
+    - "@apache-mynewt-core/sys/console/full"
+    - "@apache-mynewt-core/sys/log/full"
+    - "@apache-mynewt-core/sys/stats/full"
+    - "@apache-mynewt-core/sys/log/modlog"
+    - "@apache-mynewt-nimble/nimble/host"
+    - "@apache-mynewt-nimble/nimble/host/util/"
+    - "@apache-mynewt-nimble/nimble/host/store/config"
+    - "@apache-mynewt-nimble/nimble/transport"

--- a/newt_dump/proj/repos/apache-mynewt-nimble/apps/scanner/syscfg.yml
+++ b/newt_dump/proj/repos/apache-mynewt-nimble/apps/scanner/syscfg.yml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+syscfg.vals:
+    BLE_ROLE_BROADCASTER: 0
+    BLE_ROLE_CENTRAL: 0
+    BLE_ROLE_OBSERVER: 1
+    BLE_ROLE_PERIPHERAL: 0


### PR DESCRIPTION
Advertiser and scanner are apps implementing only Broadcaster and
Observer roles, respectively. Adding these will allows to check if stack
builds correctly if BLE_ROLE_OBSERVER is enabled without
BLE_ROLE_CENTRAL and BLE_ROLE_BROADCASTER is enabled without
BLE_ROLE_PERIPHERAL.