### PR TITLE
osx: Fix brew install gcc5

### DIFF
--- a/osx_travis_install.sh
+++ b/osx_travis_install.sh
@@ -29,13 +29,6 @@ else
     $HOME/ci/newt_install.sh
 fi
 
-if [ "${TEST}" == "TEST_ALL" ] || [ "${TEST}" == "TEST_NEWT" ]; then
-    # conflicts with gcc5
-    brew cask uninstall oclint
-
-    PKGS=(gcc5)
-fi
-
 if [ "${TEST}" != "TEST_ALL" ]; then
     brew untap caskroom/cask
 
@@ -46,16 +39,9 @@ if [ "${TEST}" != "TEST_ALL" ]; then
     git checkout b3a2e0c930~
     popd
 
-    PKGS=()
-
     # FIXME: casks don't work with `fetch --retry`
     brew cask install gcc-arm-embedded
 fi
-
-for pkg in ${PKGS[@]}; do
-    brew fetch --retry $pkg
-    brew install $pkg
-done
 
 if [[ $TRAVIS_REPO_SLUG =~ mynewt-nimble && $TEST == "BUILD_PORTS" ]]; then
     # RIOT-OS requires update to Python3


### PR DESCRIPTION
Install packages from .travis.yml. Installing them from bash script
seems buggy.

From Travis CI logs:
```
brew cask uninstall oclint

Error: Cask 'oclint' is not installed.
[...]
Downloading
https://homebrew.bintray.com/bottles/gcc@5-5.5.0.sierra.bottle.tar.gz

curl: (22) The requested URL returned error: 403 Forbidden

Error: Failed to download resource "gcc@5"
```