### PR TITLE
Use Go >=1.16 style go install

### DIFF
--- a/newt_install.sh
+++ b/newt_install.sh
@@ -27,16 +27,10 @@ retry_3_times() {
 }
 
 export GOPATH=$HOME/gopath
-export GO111MODULE=on
 
 mkdir -p $HOME/bin $GOPATH || true
 
 go version
-
-retry_3_times go get -v mynewt.apache.org/newt/newt
-
-rm -rf $GOPATH/bin $GOPATH/pkg
-
-retry_3_times go install -v mynewt.apache.org/newt/newt
+retry_3_times go install -v mynewt.apache.org/newt/newt@latest
 
 cp $GOPATH/bin/newt $HOME/bin


### PR DESCRIPTION
With Go 1.16 we can just do go install with version suffix.
Also GO111MODULES=on is default starting with Go 1.16.