### PR TITLE
Remove bsncent and bsnprph targets

### DIFF
--- a/mynewt-core-targets/nordic_pca10056_bsncent/pkg.yml
+++ b/mynewt-core-targets/nordic_pca10056_bsncent/pkg.yml
@@ -1,6 +1,0 @@
-pkg.name: "targets/nordic_pca10056_bsncent"
-pkg.type: "target"
-pkg.description: 
-pkg.author: 
-pkg.homepage: 
-

--- a/mynewt-core-targets/nordic_pca10056_bsncent/target.yml
+++ b/mynewt-core-targets/nordic_pca10056_bsncent/target.yml
@@ -1,2 +1,0 @@
-target.app: "@apache-mynewt-core/apps/bsncent"
-target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"

--- a/mynewt-core-targets/nordic_pca10056_bsnprph/pkg.yml
+++ b/mynewt-core-targets/nordic_pca10056_bsnprph/pkg.yml
@@ -1,6 +1,0 @@
-pkg.name: "targets/nordic_pca10056_bsnprph"
-pkg.type: "target"
-pkg.description: 
-pkg.author: 
-pkg.homepage: 
-

--- a/mynewt-core-targets/nordic_pca10056_bsnprph/target.yml
+++ b/mynewt-core-targets/nordic_pca10056_bsnprph/target.yml
@@ -1,2 +1,0 @@
-target.app: "@apache-mynewt-core/apps/bsnprph"
-target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"


### PR DESCRIPTION
We need to resolve issues with strict scheduling in Nimble first.