### PR TITLE
Use more recent OSX

### DIFF
--- a/osx_travis_install.sh
+++ b/osx_travis_install.sh
@@ -30,17 +30,7 @@ else
 fi
 
 if [ "${TEST}" != "TEST_ALL" ]; then
-    brew untap caskroom/cask
-
-    # Tap full clone to allow checkout of specific sha below
-    brew tap --full homebrew/cask
-
-    pushd /usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask
-    git checkout b3a2e0c930~
-    popd
-
-    # FIXME: casks don't work with `fetch --retry`
-    brew cask install gcc-arm-embedded
+    brew install gcc-arm-embedded
 fi
 
 if [[ $TRAVIS_REPO_SLUG =~ mynewt-nimble && $TEST == "BUILD_PORTS" ]]; then

--- a/test_newt_cmds.sh
+++ b/test_newt_cmds.sh
@@ -54,7 +54,7 @@ declare -a commands=(
 "newt upgrade -v"
 )
 
-if [ "${TRAVIS_OS_NAME}" != "windows" ]; then
+if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
     commands+=("newt test @apache-mynewt-core/util/cbmem")
     commands+=("newt build my_blinky_sim")
     commands+=("newt clean my_blinky_sim")


### PR DESCRIPTION
This will work with "xcode13.2" image (i.e. MacOS 12.1).

"brew install" can be used directly to install ARM toolchain and also
there's progress bar included so build will not timeout.

Since there's no support for 32-bit native images there, we shoud run
"newt test" only on Linux now.