### PR TITLE
Update newt dump answers

### DIFF
--- a/newt_dump/answers/bleprph-nrf52840pdk.json
+++ b/newt_dump/answers/bleprph-nrf52840pdk.json
@@ -7493,14 +7493,14 @@
                 "package": "@apache-mynewt-core/sys/config"
             },
             {
-                "name": "ble_hci_ram_init",
-                "stage": 100,
-                "package": "@apache-mynewt-nimble/nimble/transport/ram"
-            },
-            {
                 "name": "log_init",
                 "stage": 100,
                 "package": "@apache-mynewt-core/sys/log/full"
+            },
+            {
+                "name": "modlog_init",
+                "stage": 100,
+                "package": "@apache-mynewt-core/sys/log/modlog"
             },
             {
                 "name": "mfg_init",
@@ -7508,9 +7508,9 @@
                 "package": "@apache-mynewt-core/sys/mfg"
             },
             {
-                "name": "modlog_init",
+                "name": "ble_hci_ram_init",
                 "stage": 100,
-                "package": "@apache-mynewt-core/sys/log/modlog"
+                "package": "@apache-mynewt-nimble/nimble/transport/ram"
             },
             {
                 "name": "ble_hs_init",
@@ -7548,6 +7548,11 @@
                 "package": "@apache-mynewt-nimble/nimble/host/services/ans"
             },
             {
+                "name": "split_app_init",
+                "stage": 500,
+                "package": "@apache-mynewt-core/boot/split"
+            },
+            {
                 "name": "ble_store_config_init",
                 "stage": 500,
                 "package": "@apache-mynewt-nimble/nimble/host/store/config"
@@ -7558,19 +7563,14 @@
                 "package": "@apache-mynewt-core/sys/id"
             },
             {
-                "name": "imgmgr_module_init",
-                "stage": 500,
-                "package": "@apache-mynewt-core/mgmt/imgmgr"
-            },
-            {
                 "name": "nmgr_pkg_init",
                 "stage": 500,
                 "package": "@apache-mynewt-core/mgmt/newtmgr"
             },
             {
-                "name": "split_app_init",
+                "name": "imgmgr_module_init",
                 "stage": 500,
-                "package": "@apache-mynewt-core/boot/split"
+                "package": "@apache-mynewt-core/mgmt/imgmgr"
             },
             {
                 "name": "newtmgr_ble_pkg_init",

--- a/newt_dump/answers/btshell-nrf52840pdk.json
+++ b/newt_dump/answers/btshell-nrf52840pdk.json
@@ -5854,6 +5854,11 @@
                 "package": "@apache-mynewt-core/sys/console/full"
             },
             {
+                "name": "mfg_init",
+                "stage": 100,
+                "package": "@apache-mynewt-core/sys/mfg"
+            },
+            {
                 "name": "ble_hci_ram_init",
                 "stage": 100,
                 "package": "@apache-mynewt-nimble/nimble/transport/ram"
@@ -5862,11 +5867,6 @@
                 "name": "log_init",
                 "stage": 100,
                 "package": "@apache-mynewt-core/sys/log/full"
-            },
-            {
-                "name": "mfg_init",
-                "stage": 100,
-                "package": "@apache-mynewt-core/sys/mfg"
             },
             {
                 "name": "modlog_init",
@@ -5899,14 +5899,14 @@
                 "package": "@apache-mynewt-nimble/nimble/host/services/ans"
             },
             {
-                "name": "ble_store_ram_init",
-                "stage": 500,
-                "package": "@apache-mynewt-nimble/nimble/host/store/ram"
-            },
-            {
                 "name": "shell_init",
                 "stage": 500,
                 "package": "@apache-mynewt-core/sys/shell"
+            },
+            {
+                "name": "ble_store_ram_init",
+                "stage": 500,
+                "package": "@apache-mynewt-nimble/nimble/host/store/ram"
             }
         ]
     },

--- a/newt_dump/answers/btshell-nrf52dk.json
+++ b/newt_dump/answers/btshell-nrf52dk.json
@@ -5854,24 +5854,24 @@
                 "package": "@apache-mynewt-core/sys/console/full"
             },
             {
-                "name": "ble_hci_ram_init",
-                "stage": 100,
-                "package": "@apache-mynewt-nimble/nimble/transport/ram"
-            },
-            {
-                "name": "log_init",
-                "stage": 100,
-                "package": "@apache-mynewt-core/sys/log/full"
-            },
-            {
                 "name": "mfg_init",
                 "stage": 100,
                 "package": "@apache-mynewt-core/sys/mfg"
             },
             {
+                "name": "ble_hci_ram_init",
+                "stage": 100,
+                "package": "@apache-mynewt-nimble/nimble/transport/ram"
+            },
+            {
                 "name": "modlog_init",
                 "stage": 100,
                 "package": "@apache-mynewt-core/sys/log/modlog"
+            },
+            {
+                "name": "log_init",
+                "stage": 100,
+                "package": "@apache-mynewt-core/sys/log/full"
             },
             {
                 "name": "ble_hs_init",


### PR DESCRIPTION
The order of some packages changed in dump output due to different
sorting method used for stages.